### PR TITLE
Add info on getting the "device" cgroup in it's own heirarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ kick AppArmor out of the equation:
 docker run -privileged -lxc-conf="lxc.aa_profile=unconfined" -t -i dind
 ```
 
+If you get the warning:
+
+````
+WARNING: the 'devices' cgroup should be in its own hierarchy.
+````
+
+When starting up dind, you can get around this by shutting down docker and running:
+
+````
+# /etc/init.d/lxc stop
+# umount /sys/fs/cgroup/
+# mount -t cgroup devices 1 /sys/fs/cgroup
+````
+
+If the unmount fails, you can find out the proper mount-point with:
+
+````
+$ cat /proc/mounts | grep cgroup
+````
 
 ## How It Works
 


### PR DESCRIPTION
I won't be offended if you ignore this pull request, but since I spent a few hours trying to figure this one out I thought I'd throw it your way.

BTW: This is great!  I'm hoping to build a reproducible test suit ontop of this for [a program](https://github.com/subuser-security/subuser) that uses docker :)
