### PR TITLE
Redirect daemon output to /var/log/docker.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@ Build the image:
 docker build -t dind .
 ```
 
-Run Docker-in-Docker and get a shell where you can play:
+Run Docker-in-Docker and get a shell where you can play, and docker daemon logs
+to stdout:
 ```bash
 docker run --privileged -t -i dind
+```
+
+Run Docker-in-Docker and get a shell where you can play, but docker daemon logs
+into `/var/log/docker.log`:
+```bash
+docker run --privileged -t -i -e LOG=file dind
 ```
 
 Run Docker-in-Docker and expose the inside Docker to the outside world:

--- a/wrapdocker
+++ b/wrapdocker
@@ -2,6 +2,7 @@
 
 # First, make sure that cgroups are mounted correctly.
 CGROUP=/sys/fs/cgroup
+: {LOG:=stdio}
 
 [ -d $CGROUP ] || 
 	mkdir $CGROUP
@@ -88,7 +89,11 @@ if [ "$PORT" ]
 then
 	exec docker -d -H 0.0.0.0:$PORT
 else
-
-	docker -d &>/var/log/docker.log &
+	if [ "$LOG" == "file" ]
+	then
+		docker -d &>/var/log/docker.log &
+	else
+		docker -d &
+	fi
 	exec bash
 fi


### PR DESCRIPTION
when somebody wants to play inside the same container where dind is running, can do:

```
docker run --privileged -it jpetazzo/dind
```

which starts docker in the background, and spawns a `/bin/bash` which is fine,
bu docker daemon log and docker client command output is mixed:

```
# docker images
2014/06/26 10:46:05 GET /v1.11/images/json
[87dddcd3] +job images()
[87dddcd3] -job images() = OK (0)
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
```

with the proposed changes docker daemon'g log would go to `/var/log/docker.log`
making a clean client output:

```
# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
```
