### PR TITLE
add e2fsprogs package

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER amitsaha.in@gmail.com
 # Let's start with some basic stuff.
 RUN yum -y clean all
 RUN yum -y update
-RUN yum install -y iptables ca-certificates lxc
+RUN yum install -y iptables ca-certificates lxc e2fsprogs
 
 # Install Docker from Fedora repos
 RUN yum -y install docker-io


### PR DESCRIPTION
the fedora container was giving me a 

```
> $ docker run --privileged -t -i dind_fedora
[root@1b158166100f /]# 2014/10/10 08:42:26 docker daemon: 1.2.0 fa7b24f/1.2.0; execdriver: native; graphdriver: 
[1bb2074b] +job serveapi(unix:///var/run/docker.sock)
[info] Listening for HTTP on unix (/var/run/docker.sock)
2014/10/10 08:42:26 exec: "mkfs.ext4": executable file not found in $PATH
```
