### PR TITLE
Format Dockerfile following best-practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,17 @@ FROM ubuntu:14.04
 MAINTAINER jerome.petazzoni@docker.com
 
 # Let's start with some basic stuff.
-RUN apt-get update -qq
-RUN apt-get install -qqy iptables ca-certificates lxc
-
+RUN apt-get update -qq && apt-get install -qqy \
+    apt-transport-https \
+    ca-certificates \
+    lxc \
+    iptables
+    
 # Install Docker from Docker Inc. repositories.
-RUN apt-get install -qqy apt-transport-https
-RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-RUN apt-get update -qq
-RUN apt-get install -qqy lxc-docker
+RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 \
+  && apt-get update -qq \
+  && apt-get install -qqy lxc-docker
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker


### PR DESCRIPTION
In particular, we want to run `apt-get update` and `apt-get install` on the same line to avoid caching issues.  
Also reduces the number of AUFS layers as recommended, https://docs.docker.com/articles/dockerfile_best-practices/

A few additional things might be worth considering(?):
- Why ubuntu:14.04 by default?  A Debian base, as mentioned in the article, would be considerably smaller.
- perhaps consider COPY in place of ADD

(apologies for such pedantic edits!)
