### PR TITLE
Allow replacing bash by custom command passed as first argument to wrapdocker.

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -95,5 +95,5 @@ else
 	else
 		docker -d $DOCKER_DAEMON_ARGS &
 	fi
-	exec bash
+	exec ${1-bash}
 fi


### PR DESCRIPTION
This makes creating inherited containers a little more convenient, for instance a gocd agent container would be something like:

    FROM dind
    # commands to install undaemonized go-agent go here
    CMD ["wrapdocker", "/usr/share/go-agent/agent.sh"]