### PR TITLE
fix build for TLS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,12 @@ MAINTAINER jerome.petazzoni@docker.com
 RUN apt-get update -qq && apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
+    curl \
     lxc \
     iptables
     
 # Install Docker from Docker Inc. repositories.
-RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9 \
-  && apt-get update -qq \
-  && apt-get install -qqy lxc-docker
+RUN curl -sSL https://get.docker.com/ubuntu/ | sh
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker


### PR DESCRIPTION
The old way causes the following error:

```
root@e5028564848c:/# docker ps
FATA[0000] Get http:///var/run/docker.sock/v1.16/containers/json: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS? 
```

Installing via curl grabs the latest and fixes the TLS issue.