### PR TITLE
Keep /var/run/docker.sock when PORT is specified

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -87,7 +87,8 @@ rm -rf /var/run/docker.pid
 # otherwise, spawn a shell as well
 if [ "$PORT" ]
 then
-	exec docker -d -H 0.0.0.0:$PORT $DOCKER_DAEMON_ARGS
+	exec docker -d -H 0.0.0.0:$PORT -H unix://var/run/docker.sock \
+		$DOCKER_DAEMON_ARGS
 else
 	if [ "$LOG" == "file" ]
 	then


### PR DESCRIPTION
This makes it more convenient to call docker commands from within the
container.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>