### PR TITLE
Wait Until Docker Is Ready

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -96,6 +96,15 @@ else
 	else
 		docker -d $DOCKER_DAEMON_ARGS &
 	fi
+	(( timeout = 60 + SECONDS ))
+	until docker info >/dev/null 2>&1
+	do
+		if (( SECONDS >= timeout )); then
+			echo 'Timed out trying to connect to internal docker host.' >&2
+			break
+		fi
+		sleep 1
+	done
 	[[ $1 ]] && exec "$@"
 	exec bash --login
 fi


### PR DESCRIPTION
If you try to run a docker command immediately in waitfordocker it will fail because Docker isn't quite ready yet. This change fixes that by simply waiting for it.