### PR TITLE
Allow More Args in Command

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -95,5 +95,6 @@ else
 	else
 		docker -d $DOCKER_DAEMON_ARGS &
 	fi
-	exec ${1-bash}
+	[[ $1 ]] && exec "$@"
+	exec bash --login
 fi


### PR DESCRIPTION
In its current form the `wrapdocker` command can only take a single argument, and drops the rest. This allows `wrapdocker` to take arbitrary arguments.
