### PR TITLE
Ensure that all nodes in /dev/mapper correspond to mapped devices curren...

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver
+dmsetup mknodes
+
 # First, make sure that cgroups are mounted correctly.
 CGROUP=/sys/fs/cgroup
 : {LOG:=stdio}


### PR DESCRIPTION
...tly loaded by the device-mapper kernel driver.

When stopping and restarting DIND containers based on `wrapdocker` you sometimes run into issues like:

```bash
Service 'my_jenkins_job' failed to build: Can't set task name /dev/mapper/docker-253:4-408036-pool
```

The solution to this is to ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver. You do this by running:

```bash
dmsetup mknodes
```

before running the rest of the command in `wrapdocker`.

You can read more about the problem in my <a href="http://www.jayway.com/2015/03/14/docker-in-docker-with-jenkins-and-supervisord/">blog post</a>.