### PR TITLE
Allow changing workdir on docker run

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -90,7 +90,7 @@ rm -rf /var/run/docker.pid
 # otherwise, spawn a shell as well
 if [ "$PORT" ]
 then
-	exec docker -d -H 0.0.0.0:$PORT -H unix://var/run/docker.sock \
+	exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
 		$DOCKER_DAEMON_ARGS
 else
 	if [ "$LOG" == "file" ]


### PR DESCRIPTION
If you are running this with command: 
  -  docker run -it -w="/some/path" jpetazzo/dind

The path to the unix socket was invalid! 

it should be unix://<path> and we want path to be absoulte...

proof:
https://docs.docker.com/reference/api/docker_remote_api/