### PR TITLE
Install e2fsprogs and apparmor-parser requirements

### DIFF
--- a/opensuse/Dockerfile
+++ b/opensuse/Dockerfile
@@ -1,10 +1,10 @@
 FROM opensuse:latest
-MAINTAINER git@yeoldegrove.de
+MAINTAINER hayderimran7@gmail.com
 
 # Let's start with some basic stuff.
 RUN zypper --gpg-auto-import-keys --non-interactive refresh && \
     zypper --gpg-auto-import-keys --non-interactive update && \
-    zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses docker
+    zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses e2fsprogs apparmor-parser docker
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker

--- a/opensuse/Dockerfile
+++ b/opensuse/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse:latest
-MAINTAINER hayderimran7@gmail.com
+MAINTAINER git@yeoldegrove.de
 
 # Let's start with some basic stuff.
 RUN zypper --gpg-auto-import-keys --non-interactive refresh && \


### PR DESCRIPTION
* e2fsprogs is generally needed for docker mkfs.ext4 in systems that use rpms like centos, opensuse etc. and it doesnt get installed by default on opensuse.
* apparmor-parser needs to be installed as i tested otherwise you will get ` Error loading docker apparmor profile: fork/exec /sbin/apparmor_parser: no such file or directory ()`