### PR TITLE
DinD image using Docker binary

### DIFF
--- a/binary/Dockerfile
+++ b/binary/Dockerfile
@@ -1,20 +1,21 @@
 FROM alpine:3.2
 MAINTAINER t.dettrick@uq.edu.au
 
-# Dependencies
-RUN apk add --update iptables ca-certificates lxc e2fsprogs && \
-  rm -rf /var/cache/apk/*
-
 # Fake dmsetup, as device-mapper isn't compatible for static builds
 ADD ./dmsetup /usr/local/bin/dmsetup
 
-# Install Docker from binary
-ADD https://get.docker.com/builds/Linux/x86_64/docker-latest /usr/local/bin/docker
-
 # Install the magic wrapper
 ADD ./wrapdocker /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/dmsetup /usr/local/bin/docker /usr/local/bin/wrapdocker 
 
-# Define additional metadata for our image.
+# Dependencies & Install
+RUN DOCKER_VERSION=latest && \
+  apk add --update iptables curl ca-certificates lxc e2fsprogs && \
+  curl -L https://get.docker.com/builds/Linux/x86_64/docker-$DOCKER_VERSION \
+    > /usr/local/bin/docker && \
+  chmod +x /usr/local/bin/* && \
+  apk del --purge curl && \
+  rm -rf /var/cache/apk/*
+
+# Docker volume and run command
 VOLUME /var/lib/docker
 CMD ["wrapdocker"]

--- a/binary/Dockerfile
+++ b/binary/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.2
+MAINTAINER t.dettrick@uq.edu.au
+
+# Dependencies
+RUN apk add --update iptables ca-certificates lxc e2fsprogs && \
+  rm -rf /var/cache/apk/*
+
+# Fake dmsetup, as device-mapper isn't compatible for static builds
+ADD ./dmsetup /usr/local/bin/dmsetup
+
+# Install Docker from binary
+ADD https://get.docker.com/builds/Linux/x86_64/docker-latest /usr/local/bin/docker
+
+# Install the magic wrapper
+ADD ./wrapdocker /usr/local/bin/wrapdocker
+RUN chmod +x /usr/local/bin/dmsetup /usr/local/bin/docker /usr/local/bin/wrapdocker 
+
+# Define additional metadata for our image.
+VOLUME /var/lib/docker
+CMD ["wrapdocker"]

--- a/binary/build.sh
+++ b/binary/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp ../wrapdocker .
+docker build -t dind_binary .
+rm wrapdocker

--- a/binary/dmsetup
+++ b/binary/dmsetup
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Static binary - devicemapper storage driver not available"
+echo "Skipping dmsetup"


### PR DESCRIPTION
At ~29MB this is smaller than the current images while providing the latest version of Docker. It's also simple to modify in case you want to run a specific version of Docker.

No `devicemapper` storage driver of course, but some people won't care. There is a warning which notes why it's not available when the image starts.
