### PR TITLE
Update Fedora build to use latest

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,13 +1,8 @@
-FROM fedora:20
+FROM fedora:22
 MAINTAINER amitsaha.in@gmail.com
 
-# Let's start with some basic stuff.
-RUN yum -y clean all
-RUN yum -y update
-RUN yum install -y iptables ca-certificates lxc e2fsprogs
-
-# Install Docker from Fedora repos
-RUN yum -y install docker-io
+# Install docker
+RUN dnf -y update && dnf -y install docker && dnf clean all
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker
@@ -16,4 +11,3 @@ RUN chmod +x /usr/local/bin/wrapdocker
 # Define additional metadata for our image.
 VOLUME /var/lib/docker
 CMD ["wrapdocker"]
-


### PR DESCRIPTION
 - dnf replaces yum as of Fedora 22
 - only the docker package needs to be installed
 - 'dnf clean all' after package installation minimizes the size of
   intermediate layers