### PR TITLE
Overlay support (and other cleanup)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,4 @@ ADD ./wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
-VOLUME /var/lib/docker
 ENTRYPOINT ["wrapdocker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@ FROM ubuntu:14.04
 MAINTAINER jerome.petazzoni@docker.com
 
 # Let's start with some basic stuff.
-RUN apt-get update -qq && apt-get install -qqy \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    lxc \
-    iptables
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qqy --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        lxc \
+        iptables \
+        && \
+    apt-get clean
     
 # Install Docker from Docker Inc. repositories.
 RUN curl -sSL https://get.docker.com/ubuntu/ | sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -qq && \
     apt-get clean
     
 # Install Docker from Docker Inc. repositories.
-RUN curl -sSL https://get.docker.com/ubuntu/ | sh
+RUN curl -sSL https://get.docker.com/ | sh
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,4 @@ RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
 VOLUME /var/lib/docker
-CMD ["wrapdocker"]
-
+ENTRYPOINT ["wrapdocker"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -13,5 +13,4 @@ RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
 VOLUME /var/lib/docker
-CMD ["wrapdocker"]
-
+ENTRYPOINT ["wrapdocker"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,5 +12,4 @@ ADD ./wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
-VOLUME /var/lib/docker
 ENTRYPOINT ["wrapdocker"]

--- a/archlinux/Dockerfile
+++ b/archlinux/Dockerfile
@@ -10,5 +10,4 @@ RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
 VOLUME /var/lib/docker
-CMD ["wrapdocker"]
-
+ENTRYPOINT ["wrapdocker"]

--- a/archlinux/Dockerfile
+++ b/archlinux/Dockerfile
@@ -9,5 +9,4 @@ ADD ./wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
-VOLUME /var/lib/docker
 ENTRYPOINT ["wrapdocker"]

--- a/binary/Dockerfile
+++ b/binary/Dockerfile
@@ -18,4 +18,4 @@ RUN DOCKER_VERSION=latest && \
 
 # Docker volume and run command
 VOLUME /var/lib/docker
-CMD ["wrapdocker"]
+ENTRYPOINT ["wrapdocker"]

--- a/binary/Dockerfile
+++ b/binary/Dockerfile
@@ -17,5 +17,4 @@ RUN DOCKER_VERSION=latest && \
   rm -rf /var/cache/apk/*
 
 # Docker volume and run command
-VOLUME /var/lib/docker
 ENTRYPOINT ["wrapdocker"]

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -10,4 +10,4 @@ RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
 VOLUME /var/lib/docker
-CMD ["wrapdocker"]
+ENTRYPOINT ["wrapdocker"]

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -9,5 +9,4 @@ ADD ./wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
-VOLUME /var/lib/docker
 ENTRYPOINT ["wrapdocker"]

--- a/opensuse/Dockerfile
+++ b/opensuse/Dockerfile
@@ -12,5 +12,4 @@ RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
 VOLUME /var/lib/docker
-CMD ["wrapdocker"]
-
+ENTRYPOINT ["wrapdocker"]

--- a/opensuse/Dockerfile
+++ b/opensuse/Dockerfile
@@ -11,5 +11,4 @@ ADD ./wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
-VOLUME /var/lib/docker
 ENTRYPOINT ["wrapdocker"]

--- a/wrapdocker
+++ b/wrapdocker
@@ -95,6 +95,9 @@ else
     docker -d ${DOCKER_DAEMON_ARGS} &
   fi
 
+  # Cleany shutdown docker daemon on exit to avoid resource leaks
+  trap 'service docker stop' EXIT
+
   (( timeout = 60 + SECONDS ))
   until docker info >/dev/null 2>&1; do
     if (( SECONDS >= timeout )); then

--- a/wrapdocker
+++ b/wrapdocker
@@ -7,77 +7,74 @@ dmsetup mknodes
 CGROUP=/sys/fs/cgroup
 : {LOG:=stdio}
 
-[ -d $CGROUP ] || 
-	mkdir $CGROUP
+[ -d ${CGROUP} ] ||
+  mkdir ${CGROUP}
 
-mountpoint -q $CGROUP || 
-	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
-		echo "Could not make a tmpfs mount. Did you use --privileged?"
-		exit 1
-	}
+mountpoint -q ${CGROUP} ||
+  mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup ${CGROUP} || {
+    echo "Could not make a tmpfs mount. Did you use --privileged?"
+    exit 1
+  }
 
-if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security
-then
-    mount -t securityfs none /sys/kernel/security || {
-        echo "Could not mount /sys/kernel/security."
-        echo "AppArmor detection and --privileged mode might break."
-    }
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+  mount -t securityfs none /sys/kernel/security || {
+    echo "Could not mount /sys/kernel/security."
+    echo "AppArmor detection and --privileged mode might break."
+  }
 fi
 
 # Mount the cgroup hierarchies exactly as they are in the parent system.
-for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
-do
-        [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
-        mountpoint -q $CGROUP/$SUBSYS || 
-                mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
+for SUBSYS in $(cut -d: -f2 /proc/1/cgroup); do
+  [ -d ${CGROUP}/${SUBSYS} ] || mkdir ${CGROUP}/${SUBSYS}
+  mountpoint -q ${CGROUP}/${SUBSYS} ||
+    mount -n -t cgroup -o ${SUBSYS} cgroup ${CGROUP}/${SUBSYS}
 
-        # The two following sections address a bug which manifests itself
-        # by a cryptic "lxc-start: no ns_cgroup option specified" when
-        # trying to start containers withina container.
-        # The bug seems to appear when the cgroup hierarchies are not
-        # mounted on the exact same directories in the host, and in the
-        # container.
+  # The two following sections address a bug which manifests itself
+  # by a cryptic "lxc-start: no ns_cgroup option specified" when
+  # trying to start containers withina container.
+  # The bug seems to appear when the cgroup hierarchies are not
+  # mounted on the exact same directories in the host, and in the
+  # container.
 
-        # Named, control-less cgroups are mounted with "-o name=foo"
-        # (and appear as such under /proc/<pid>/cgroup) but are usually
-        # mounted on a directory named "foo" (without the "name=" prefix).
-        # Systemd and OpenRC (and possibly others) both create such a
-        # cgroup. To avoid the aforementioned bug, we symlink "foo" to
-        # "name=foo". This shouldn't have any adverse effect.
-        echo $SUBSYS | grep -q ^name= && {
-                NAME=$(echo $SUBSYS | sed s/^name=//)
-                ln -s $SUBSYS $CGROUP/$NAME
-        }
+  # Named, control-less cgroups are mounted with "-o name=foo"
+  # (and appear as such under /proc/<pid>/cgroup) but are usually
+  # mounted on a directory named "foo" (without the "name=" prefix).
+  # Systemd and OpenRC (and possibly others) both create such a
+  # cgroup. To avoid the aforementioned bug, we symlink "foo" to
+  # "name=foo". This shouldn't have any adverse effect.
+  echo ${SUBSYS} | grep -q ^name= && {
+    NAME=$(echo ${SUBSYS} | sed s/^name=//)
+    ln -s ${SUBSYS} ${CGROUP}/${NAME}
+  }
 
-        # Likewise, on at least one system, it has been reported that
-        # systemd would mount the CPU and CPU accounting controllers
-        # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
-        # but on a directory called "cpu,cpuacct" (note the inversion
-        # in the order of the groups). This tries to work around it.
-        [ $SUBSYS = cpuacct,cpu ] && ln -s $SUBSYS $CGROUP/cpu,cpuacct
+  # Likewise, on at least one system, it has been reported that
+  # systemd would mount the CPU and CPU accounting controllers
+  # (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+  # but on a directory called "cpu,cpuacct" (note the inversion
+  # in the order of the groups). This tries to work around it.
+  [ ${SUBSYS} = cpuacct,cpu ] && ln -s ${SUBSYS} ${CGROUP}/cpu,cpuacct
 done
 
 # Note: as I write those lines, the LXC userland tools cannot setup
 # a "sub-container" properly if the "devices" cgroup is not in its
 # own hierarchy. Let's detect this and issue a warning.
 grep -q :devices: /proc/1/cgroup ||
-	echo "WARNING: the 'devices' cgroup should be in its own hierarchy."
+  echo "WARNING: the 'devices' cgroup should be in its own hierarchy."
 grep -qw devices /proc/1/cgroup ||
-	echo "WARNING: it looks like the 'devices' cgroup is not mounted."
+  echo "WARNING: it looks like the 'devices' cgroup is not mounted."
 
 # Now, close extraneous file descriptors.
 pushd /proc/self/fd >/dev/null
-for FD in *
-do
-	case "$FD" in
-	# Keep stdin/stdout/stderr
-	[012])
-		;;
-	# Nuke everything else
-	*)
-		eval exec "$FD>&-"
-		;;
-	esac
+for FD in *; do
+  case "${FD}" in
+  # Keep stdin/stdout/stderr
+  [012])
+    ;;
+  # Nuke everything else
+  *)
+    eval exec "${FD}>&-"
+    ;;
+  esac
 done
 popd >/dev/null
 
@@ -88,26 +85,25 @@ rm -rf /var/run/docker.pid
 
 # If we were given a PORT environment variable, start as a simple daemon;
 # otherwise, spawn a shell as well
-if [ "$PORT" ]
-then
-	exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
-		$DOCKER_DAEMON_ARGS
+if [ ! -z "${PORT}" ]; then
+  exec docker -d  ${DOCKER_DAEMON_ARGS} \
+    -H 0.0.0.0:${PORT} -H unix:///var/run/docker.sock \
 else
-	if [ "$LOG" == "file" ]
-	then
-		docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
-	else
-		docker -d $DOCKER_DAEMON_ARGS &
-	fi
-	(( timeout = 60 + SECONDS ))
-	until docker info >/dev/null 2>&1
-	do
-		if (( SECONDS >= timeout )); then
-			echo 'Timed out trying to connect to internal docker host.' >&2
-			exit 1
-		fi
-		sleep 1
-	done
-	[[ $1 ]] && exec "$@"
-	exec bash --login
+  if [ "${LOG}" == "file" ]; then
+    docker -d ${DOCKER_DAEMON_ARGS} &>/var/log/docker.log &
+  else
+    docker -d ${DOCKER_DAEMON_ARGS} &
+  fi
+
+  (( timeout = 60 + SECONDS ))
+  until docker info >/dev/null 2>&1; do
+    if (( SECONDS >= timeout )); then
+      echo 'Timed out trying to connect to internal docker host.' >&2
+      exit 1
+    fi
+    sleep 1
+  done
+
+  [[ $1 ]] && exec "$@"
+  exec bash --login
 fi

--- a/wrapdocker
+++ b/wrapdocker
@@ -116,13 +116,13 @@ rm -rf /var/run/docker.pid
 # If we were given a PORT environment variable, start as a simple daemon;
 # otherwise, spawn a shell as well
 if [ ! -z "${PORT}" ]; then
-  exec docker -d  ${DOCKER_DAEMON_ARGS} \
+  exec docker daemon ${DOCKER_DAEMON_ARGS} \
     -H 0.0.0.0:${PORT} -H unix:///var/run/docker.sock \
 else
   if [ "${LOG}" == "file" ]; then
-    docker -d ${DOCKER_DAEMON_ARGS} &>/var/log/docker.log &
+    docker daemon ${DOCKER_DAEMON_ARGS} &>/var/log/docker.log &
   else
-    docker -d ${DOCKER_DAEMON_ARGS} &
+    docker daemon ${DOCKER_DAEMON_ARGS} &
   fi
 
   # Cleany shutdown docker daemon on exit to avoid resource leaks

--- a/wrapdocker
+++ b/wrapdocker
@@ -104,7 +104,7 @@ else
 	do
 		if (( SECONDS >= timeout )); then
 			echo 'Timed out trying to connect to internal docker host.' >&2
-			break
+			exit 1
 		fi
 		sleep 1
 	done

--- a/wrapdocker
+++ b/wrapdocker
@@ -78,6 +78,36 @@ for FD in *; do
 done
 popd >/dev/null
 
+# find supported filesystem to use for docker image mounts
+if grep -q overlay /proc/filesystems; then
+  STORAGE_FS=overlay
+elif grep -q aufs /proc/filesystems; then
+  STORAGE_FS=aufs
+else
+  echo "No supported filesystem found (aufs, overlay)"
+  exit 1
+fi
+
+# find filesystem below /var/lib/docker
+STORAGE_DIR="/var/lib/docker"
+mkdir -p "${STORAGE_DIR}"
+STORAGE_DIR_FS=$(df -PTh "${STORAGE_DIR}" | awk '{print $2}' | tail -1)
+
+# Unless using overlay over overlay, create an ext3 loop device as an intermediary layer.
+# The max size of the loop device is $VAR_LIB_DOCKER_SIZE in GB (default=5).
+if [ "${STORAGE_DIR_FS}" != "overlay" ] || [ "${STORAGE_FS}" != "overlay" ]; then
+  STORAGE_FILE="/data/docker"
+  VAR_LIB_DOCKER_SIZE=${VAR_LIB_DOCKER_SIZE:-5}
+  mkdir -p "$(dirname "${STORAGE_FILE}")"
+  if [ ! -f "${STORAGE_FILE}" ]; then
+    dd if=/dev/zero of="${STORAGE_FILE}" bs=1G seek=${VAR_LIB_DOCKER_SIZE} count=0
+    echo y | mkfs.ext3 "${STORAGE_FILE}"
+  fi
+  mount -o loop "${STORAGE_FILE}" "${STORAGE_DIR}"
+fi
+
+# Set storage driver
+DOCKER_DAEMON_ARGS="${DOCKER_DAEMON_ARGS} --storage-driver=${STORAGE_FS}"
 
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.

--- a/wrapdocker
+++ b/wrapdocker
@@ -87,11 +87,13 @@ else
   echo "No supported filesystem found (aufs, overlay)"
   exit 1
 fi
+echo "Storage Filesystem: ${STORAGE_FS}"
 
 # find filesystem below /var/lib/docker
 STORAGE_DIR="/var/lib/docker"
 mkdir -p "${STORAGE_DIR}"
 STORAGE_DIR_FS=$(df -PTh "${STORAGE_DIR}" | awk '{print $2}' | tail -1)
+echo "Host Storage Filesystem: ${STORAGE_DIR_FS}"
 
 # Unless using overlay over overlay, create an ext3 loop device as an intermediary layer.
 # The max size of the loop device is $VAR_LIB_DOCKER_SIZE in GB (default=5).
@@ -100,9 +102,11 @@ if [ "${STORAGE_DIR_FS}" != "overlay" ] || [ "${STORAGE_FS}" != "overlay" ]; the
   VAR_LIB_DOCKER_SIZE=${VAR_LIB_DOCKER_SIZE:-5}
   mkdir -p "$(dirname "${STORAGE_FILE}")"
   if [ ! -f "${STORAGE_FILE}" ]; then
+    echo "Creating ext3 filesystem: ${STORAGE_FILE}"
     dd if=/dev/zero of="${STORAGE_FILE}" bs=1G seek=${VAR_LIB_DOCKER_SIZE} count=0
     echo y | mkfs.ext3 "${STORAGE_FILE}"
   fi
+  echo "Mounting loop device: ${STORAGE_DIR}"
   mount -o loop "${STORAGE_FILE}" "${STORAGE_DIR}"
 fi
 
@@ -117,7 +121,7 @@ rm -rf /var/run/docker.pid
 # otherwise, spawn a shell as well
 if [ ! -z "${PORT}" ]; then
   exec docker daemon ${DOCKER_DAEMON_ARGS} \
-    -H 0.0.0.0:${PORT} -H unix:///var/run/docker.sock \
+    -H 0.0.0.0:${PORT} -H unix:///var/run/docker.sock
 else
   if [ "${LOG}" == "file" ]; then
     docker daemon ${DOCKER_DAEMON_ARGS} &>/var/log/docker.log &


### PR DESCRIPTION
- Reduce docker image size by cleaning apt
- Use noninteractive mode and no-install-recommends to reduce noisy output when building
- Use ENTRYPOINT instead of CMD
  - Allow commands to be run without specifying wrapdocker every time
- Exit early if the docker daemon doesn't come up before the timeout.
- Bash style cleanup
  - 2 space indent (instead of mixed 4 spaces and tabs)
  - Inline then/do
  - Remove trailing line whitespace
  - Wrap simple variable usages
- Cleanly shutdown docker daemon on exit to avoid resource leaks
- Add support for OverlayFS (which allows recursive mounting)
- Fallback to AUFS when OverlayFS is not available or when not configured on the host docker
- Remove /var/lib/docker volume
- Use loop device with AUFS to allow AUFS on AUFS
- Update README
- Use docker daemon instead of deprecated docker -d (>= v1.8)

Sorry to put so many changes in one PR, but otherwise it would have been a chain of branches of branches to deal with conflict. I used multiple commits to make it easier to review. Let me know if any of these changes are unacceptable and need to be removed to accept the others.
