### PR TITLE
Change "-d" flag for "daemon" in wrapdocker to avoid deprecation

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -7,10 +7,10 @@ dmsetup mknodes
 CGROUP=/sys/fs/cgroup
 : {LOG:=stdio}
 
-[ -d $CGROUP ] || 
+[ -d $CGROUP ] ||
 	mkdir $CGROUP
 
-mountpoint -q $CGROUP || 
+mountpoint -q $CGROUP ||
 	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
 		echo "Could not make a tmpfs mount. Did you use --privileged?"
 		exit 1
@@ -28,7 +28,7 @@ fi
 for SUBSYS in $(cut -d: -f2 /proc/1/cgroup)
 do
         [ -d $CGROUP/$SUBSYS ] || mkdir $CGROUP/$SUBSYS
-        mountpoint -q $CGROUP/$SUBSYS || 
+        mountpoint -q $CGROUP/$SUBSYS ||
                 mount -n -t cgroup -o $SUBSYS cgroup $CGROUP/$SUBSYS
 
         # The two following sections address a bug which manifests itself
@@ -90,14 +90,14 @@ rm -rf /var/run/docker.pid
 # otherwise, spawn a shell as well
 if [ "$PORT" ]
 then
-	exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+	exec docker daemon -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
 		$DOCKER_DAEMON_ARGS
 else
 	if [ "$LOG" == "file" ]
 	then
-		docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+		docker daemon $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
 	else
-		docker -d $DOCKER_DAEMON_ARGS &
+		docker daemon $DOCKER_DAEMON_ARGS &
 	fi
 	(( timeout = 60 + SECONDS ))
 	until docker info >/dev/null 2>&1


### PR DESCRIPTION
When launching dind image I saw this in logs:

![image](https://cloud.githubusercontent.com/assets/2457529/12824042/85d3eb66-cb6f-11e5-8d7e-e794e1bc9547.png)

```
...
Warning: '-d' is deprecated, it will be removed soon. See usage.
WARN[0000] please use 'docker daemon' instead.          
...
```

I made that change in `wrapdocker` file. It was deprecated in `v1.8.0` and it will be removed in `v1.10`. You can check it at https://docs.docker.com/engine/misc/deprecated/.