### PR TITLE
use setsid to avoid bash ctrl+c reaching docker

### DIFF
--- a/wrapdocker
+++ b/wrapdocker
@@ -84,7 +84,7 @@ popd >/dev/null
 
 # If a pidfile is still around (for example after a container restart),
 # delete it so that docker can start.
-rm -rf /var/run/docker.pid
+rm -f /var/run/docker.pid
 
 # If we were given a PORT environment variable, start as a simple daemon;
 # otherwise, spawn a shell as well
@@ -95,9 +95,9 @@ then
 else
 	if [ "$LOG" == "file" ]
 	then
-		docker daemon $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+		setsid docker daemon $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
 	else
-		docker daemon $DOCKER_DAEMON_ARGS &
+		setsid docker daemon $DOCKER_DAEMON_ARGS &
 	fi
 	(( timeout = 60 + SECONDS ))
 	until docker info >/dev/null 2>&1


### PR DESCRIPTION
run docker in separate session

otherwise bash started with same session and pressing ctrl+c in bash
will also send same signal to docker (WTF!)

```
[root@aa62dda0e350 /]# docker run --rm  --privileged -it ed/dind bash -l
bash-4.3# ps -o pid,ppid,sid,cmd axwf
  PID  PPID   SID CMD
    1     0     1 bash -l
   40     1     1 dockerd
   55    40    55  \_ docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --shim docker-containerd
-shim     
  139     1     1 ps -o pid,ppid,sid,cmd axwf
bash-4.3# ^C
bash-4.3#  
INFO[0034] Processing signal 'interrupt'
INFO[0034] stopping containerd after receiving terminated
```
